### PR TITLE
[백엔드] 글 삭제 관련 설정 수정, 유저 프로필 사진 필드 수정

### DIFF
--- a/post/post_service.py
+++ b/post/post_service.py
@@ -11,8 +11,8 @@ from comment.comment_models import Comment
 @ login_required(login_url='login')
 def post_list(request):
     if request.method == 'GET':
-        # 모든 글 가져오기, 포스팅 날짜 역순으로 정렬
-        all_post = Post.objects.all().order_by('-created_at')
+        # 삭제처리 되지 않은 모든 글 가져오기, 포스팅 날짜 역순으로 정렬
+        all_post = Post.objects.filter(deleted=0).order_by('-created_at')
         post_list_context = {
             'all_post': all_post
         }
@@ -143,5 +143,7 @@ def delete_post(request, pk):
 
     # 글 작성자와 요청한 유저가 같은지 확인
     if posting.user.id == request.user.id:
-        posting.delete()
+        # 글을 실제로 삭제하지 않고 삭제된 것처럼 처리
+        posting.deleted = True
+        # posting.delete()
         return redirect('posts')

--- a/user/user_models.py
+++ b/user/user_models.py
@@ -69,9 +69,9 @@ class MooyahoUser(AbstractUser):
     age_gr = models.CharField(max_length=10, choices=age_gr_conf, verbose_name='연령대')
     disabled = models.BooleanField(default=False, verbose_name='탈퇴 여부')
     superuser = models.BooleanField(default=False, verbose_name='관리자 여부')
-    # profile_img = models.ImageField(blank=True, upload_to=profile_img_upload_path)
-    profile_img = models.ImageField(blank=True, upload_to=f'user/user_upload_images/',
-                                    verbose_name='프로필 사진')
+    profile_img = models.ImageField(blank=True, verbose_name='프로필 사진')
+    # profile_img = models.ImageField(blank=True, upload_to=f'user/user_upload_images/',
+    #                                 verbose_name='프로필 사진')
     exp = models.CharField(max_length=10, choices=exp_conf, verbose_name='등산 경력')
     reason = models.CharField(max_length=100, choices=reason_conf, verbose_name='등산 목적')
     latitude = models.FloatField(default=0, verbose_name='유저 위치 위도')


### PR DESCRIPTION
1. 글 삭제 시 실제로 DB에서 삭제하지 않고 삭제된 것처럼 처리하도록 변경했습니다.
2. 전체 글을 불러올 때 삭제 처리되지 않은 글만 불러오도록 코드를 수정했습니다.
3. 유저 프로필 사진 필드의 경로 옵션을 수정했습니다.