### PR TITLE
[백엔드] 수정: 닉네임 길이 제한 증가로 user model 필드 수정

### DIFF
--- a/user/user_models.py
+++ b/user/user_models.py
@@ -59,7 +59,7 @@ class MooyahoUser(AbstractUser):
     ]
 
     # 필드
-    nickname = models.CharField(max_length=10, unique=True, verbose_name='닉네임')
+    nickname = models.CharField(max_length=20, unique=True, verbose_name='닉네임')
     gender = models.CharField(max_length=2, choices=gender_conf, verbose_name='성별')
     age_gr = models.CharField(max_length=10, choices=age_gr_conf, verbose_name='연령대')
     disabled = models.BooleanField(default=False, verbose_name='탈퇴 여부')


### PR DESCRIPTION
닉네임 길이 제한에 여유를 두고자 유저 모델의 닉네임 필드 제한 길이를 20으로 증가시켰습니다.