### PR TITLE
[백엔드] 추가: 유저 요청 데이터 제한 용량 증가 위한 파일 추가

### DIFF
--- a/.platform/myconf.config
+++ b/.platform/myconf.config
@@ -1,0 +1,3 @@
+container_commands:
+  01_reload_nginx:
+    command: "service nginx reload"

--- a/.platform/nginx/conf.d/proxy.conf
+++ b/.platform/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 1G;

--- a/user/user_models.py
+++ b/user/user_models.py
@@ -59,7 +59,7 @@ class MooyahoUser(AbstractUser):
     ]
 
     # 필드
-    nickname = models.CharField(max_length=10, unique=True, verbose_name='닉네임')
+    nickname = models.CharField(max_length=20, unique=True, verbose_name='닉네임')
     gender = models.CharField(max_length=2, choices=gender_conf, verbose_name='성별')
     age_gr = models.CharField(max_length=10, choices=age_gr_conf, verbose_name='연령대')
     disabled = models.BooleanField(default=False, verbose_name='탈퇴 여부')


### PR DESCRIPTION
문제: 글 쓰기 할 때 글 내용이 많아지면 413 에러(요청 데이터 용량 초과)가 발생
원인: nginx의 client max body size 기본 설정 값 1M로 너무 작은 용량
해결 방법: AWS 공식 문서, 구글 검색 자료를 통해 nginx 설정 관련 경로와 파일을 추가했습니다.