### PR TITLE
[둘러보기] 게스트 유무 판단 값 수정(파이썬 boolean값이 True 이기 때문)

### DIFF
--- a/user/static/js/base.js
+++ b/user/static/js/base.js
@@ -1,6 +1,6 @@
 
 const clickedNavigateButton = (e) => {
-    const isAuthenticated = (e.target.parentElement.parentElement.dataset.isAuthenticated === 'true'); // 로그인 or 비로그인 확인
+    const isAuthenticated = (e.target.parentElement.parentElement.dataset.isAuthenticated === 'True'); // 로그인 or 비로그인 확인
     const publicUrlGroup = ['/mountains/', '/help/', '/login/']; // 비로그인 유저에게 오픈 된 메뉴(url) 그룹
     const url = e.target.dataset.url;
     


### PR DESCRIPTION
금일 낮에 있었던 게스트 모드 에러 수정했습니다.
로그인 유무를 파이썬 boolean 값인 `True`로 판단 해야합니다. (자바스크립트는 `true`)

해당 내용은 이미 collectstatic 으로 본 서버에 적용되어 있습니다.