### PR TITLE
추가: 로고누르면 main페이지 이동, 산이름 누르면 산상세페이지 이동

### DIFF
--- a/post/static/css/posts_all.css
+++ b/post/static/css/posts_all.css
@@ -51,6 +51,17 @@
     margin-top: -0.15rem;
 }
 
+#mountain-info{
+    display:flex;
+    flex-direction: row;
+    align-items: center;
+}
+.mountain-icon{
+    margin-top: 6px;
+    margin-left: 3px;
+    font-size: 17px;
+    color: black;
+}
 /* 사진 영역 */
 .image-box {
     margin: 1rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,9 +34,9 @@
                 <div id="menu-wrapper">
                     <i class="material-icons" id="menu-icon" data-bs-toggle="offcanvas" data-bs-target="#offcanvasWithBackdrop" aria-controls="offcanvasWithBackdrop">menu</i>
                 </div>
-                <div id="logo-wrapper">
+                <a id="logo-wrapper" href="{% url 'main' %}">
                     <img src="{% static 'images/mooyaho_logo.png' %}" alt="">
-                </div>
+                </a>
                 <div id="search-back-wrapper" class="hide">
                     <i class="material-icons">arrow_back</i>
                 </div>

--- a/templates/post/detail.html
+++ b/templates/post/detail.html
@@ -24,7 +24,10 @@
                     <span>{{ clicked_post.user.nickname }}</span>
                     <div>
                         <span class="material-icons">location_on</span>
-                        <span>{{ clicked_post.mountain_name }}</span>
+                        <a href="/mountains_detail/{{ clicked_post.mountain_id }}">
+                            <span>{{ clicked_post.mountain_name }}</span>
+                        </a>
+
                         <span>&nbsp;
                             {% for i in rating %}
                                 {{ i }}

--- a/templates/post/detail.html
+++ b/templates/post/detail.html
@@ -24,10 +24,13 @@
                     <span>{{ clicked_post.user.nickname }}</span>
                     <div>
                         <span class="material-icons">location_on</span>
-                        <a href="/mountains_detail/{{ clicked_post.mountain_id }}">
+                        {% if clicked_post.mountain_id < 101%}
+                            <a href="/mountains_detail/{{ clicked_post.mountain_id }}">
+                                <span>{{ clicked_post.mountain_name }}</span>
+                            </a>
+                        {% else %}
                             <span>{{ clicked_post.mountain_name }}</span>
-                        </a>
-
+                        {% endif %}
                         <span>&nbsp;
                             {% for i in rating %}
                                 {{ i }}

--- a/templates/post/posts.html
+++ b/templates/post/posts.html
@@ -22,7 +22,14 @@
                 </div>
                 <div class="writer-info">
                     <span>{{ content.user.nickname }}</span>
-                    <span>{{ content.mountain_name }}</span>
+                    <div id="mountain-info">
+                        <span>{{ content.mountain_name }}</span>
+                        {% if content.mountain_id < 101 %}
+                            <a href="/mountains_detail/{{ content.mountain_id }}/">
+                                <span class="material-icons mountain-icon">image_search</span>
+                            </a>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
             <div class="image-box">


### PR DESCRIPTION
무야호 로고 누르면 main페이지로 이동- base.html에 main url로 이동하도록 추가하였습니다.
게시물 전체 페이지의 산클릭시 산상세페이지 이동- posts.html에 산정보가 없는 산과 구분하기 위해 산정보가 있는 산은 아이콘을 보여주어 산상세페이지로 이동하도록 추가하였습니다.
게시물 상세 페이지의 산 클릭시 산상세페이지 이동-detail.html에 산상세페이지로 이동하도록 추가하였습니다.